### PR TITLE
Update license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "Adcash"
   ],
   "author": "Adcash OU",
-  "license": "LicenseRef-LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/adcash/cordova-plugin-adcash/issues"
   },


### PR DESCRIPTION
This tiny pull request changes the `license` field in `package.json` in anticipation of impending revision of the metadata guidelines.

The relevant PR is npm/npm#8609.

Sorry for the back-and-forth on the guidelines, and special thanks for taking the time to express your special license situation in a machine-readable way. It's so great to see a fellow Node hacker taking licensing seriously!